### PR TITLE
fix: ポップアップの操作を正確に

### DIFF
--- a/src/app/(user)/_components/Header.tsx
+++ b/src/app/(user)/_components/Header.tsx
@@ -11,6 +11,12 @@ const HeaderContainer = styled.header`
   font-weight: 600;
   font-size: 32px;
   padding: 10px 0;
+
+  /* 上に固定 */
+  position: sticky;
+  top: 0;
+
+  z-index: 2;
 `;
 
 const Header: FC = () => {

--- a/src/app/(user)/_components/Header.tsx
+++ b/src/app/(user)/_components/Header.tsx
@@ -11,11 +11,8 @@ const HeaderContainer = styled.header`
   font-weight: 600;
   font-size: 32px;
   padding: 10px 0;
-
-  /* 上に固定 */
   position: sticky;
   top: 0;
-
   z-index: 2;
 `;
 

--- a/src/app/(user)/gallery/_components/Popup.tsx
+++ b/src/app/(user)/gallery/_components/Popup.tsx
@@ -29,18 +29,17 @@ const CloseButton = styled.div`
   height: 28px;
 
   position: absolute;
-  top: 10px;
-  left: 10px;
-  padding: 6px;
+  top: 12px;
+  left: 12px;
 
-  background-color: #ddd;
+  background-color: #eee;
   border-radius: 50%;
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.4);
-
-  opacity: 0.8;
+  box-shadow: 0 0 10px rgba(44, 44, 44, 0.2);
 
   :hover {
-    color: orange;
+    background-color: rgba(255, 165, 0,0.4);
+    border-radius: 50%;
+    box-shadow: 0 0 8px orange;
   }
 
   cursor: pointer;

--- a/src/app/(user)/gallery/_components/Popup.tsx
+++ b/src/app/(user)/gallery/_components/Popup.tsx
@@ -37,7 +37,7 @@ const CloseButton = styled.div`
   box-shadow: 0 0 10px rgba(44, 44, 44, 0.2);
 
   :hover {
-    background-color: rgba(255, 165, 0,0.4);
+    background-color: rgba(255, 165, 0, 0.4);
     border-radius: 50%;
     box-shadow: 0 0 8px orange;
   }

--- a/src/app/(user)/gallery/page.tsx
+++ b/src/app/(user)/gallery/page.tsx
@@ -24,9 +24,8 @@ const Background = styled.div`
   top: 0;
   left: 0;
   width: 100%;
-  margin-top: 70px;
+  height: 100%;
 
-  background-color: rgba(255, 255, 255, 0.5);
   z-index: 1;
 `;
 
@@ -59,7 +58,7 @@ const Gallery: FC = () => {
           <Popup item={chosenItem} setChose={setChose} />
         </>
       )}
-      <CardContainer>
+      <CardContainer style={isChose ? { opacity: '0.4' } : { opacity: '1' }}>
         {demo.map((item: SolidObject) => {
           return <Card key={item.id} item={item} choseItem={choseItem} />;
         })}

--- a/src/app/(user)/gallery/page.tsx
+++ b/src/app/(user)/gallery/page.tsx
@@ -7,12 +7,13 @@ import Popup from './_components/Popup';
 import demo from './_components/i18n/demo';
 import { SolidObject } from '@/src/types/SolidObject';
 
-const CardContainer = styled.div`
+const CardContainer = styled.div<{ isCose: string }>`
   margin: 0 10%;
   padding: 75px 0;
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   gap: 50px;
+  opacity: ${(props) => (props.isCose === 'true' ? '0.4' : '1')};
 
   @media screen and (max-width: 1400px) {
     margin: 0 50px;
@@ -25,7 +26,6 @@ const Background = styled.div`
   left: 0;
   width: 100%;
   height: 100%;
-
   z-index: 1;
 `;
 
@@ -39,11 +39,6 @@ const Gallery: FC = () => {
   };
 
   useEffect(() => {
-    for (let i = 0; i < demo.length; i++) {
-      if (demo[i].id === itemId) {
-        setItem(demo[i]);
-      }
-    }
     const foundItem = demo.find((item: SolidObject) => item.id === itemId);
     if (foundItem) {
       setItem(foundItem);
@@ -58,7 +53,7 @@ const Gallery: FC = () => {
           <Popup item={chosenItem} setChose={setChose} />
         </>
       )}
-      <CardContainer style={isChose ? { opacity: '0.4' } : { opacity: '1' }}>
+      <CardContainer isCose={isChose.toString()}>
         {demo.map((item: SolidObject) => {
           return <Card key={item.id} item={item} choseItem={choseItem} />;
         })}


### PR DESCRIPTION
前回から追加分のプルリクです
<img width="1680" alt="image" src="https://github.com/kanakanho/arquicklook-vision-os/assets/76000830/999516a5-5473-44a0-8975-f533fdb950e1">

- ボタンを見やすく
- ポップアップ外を選択したときにポップアップが消えるように
- ポップアップ表示時の背景透過の表示を適切に